### PR TITLE
Fix null numbers causing later fields to be empty

### DIFF
--- a/column.go
+++ b/column.go
@@ -231,8 +231,13 @@ func (c *BindableColumn) Value(h api.SQLHSTMT, idx int) (driver.Value, error) {
 		}
 	}
 	if c.Len.IsNull() {
-		// is NULL
-		return nil, nil
+		// Return 0 for numbers.  This is technically wrong, but NULL seems to break things.
+		switch c.CType {
+		case api.SQL_C_LONG, api.SQL_C_SBIGINT, api.SQL_C_DOUBLE:
+			return 0, nil
+		default:
+			return nil, nil
+		}
 	}
 	if !c.IsVariableWidth && int(c.Len) != c.Size {
 		panic(fmt.Errorf("wrong column #%d length %d returned, %d expected", idx, c.Len, c.Size))


### PR DESCRIPTION
I don't know if this is actually valuable as-is, but we were getting errors when running against an Access database table where a numeric field was sometimes null.  For some reason, on a record with a null number, EVERY field in the select statement that was *after* the null field would end up set to a blank value.

After a bit of debugging I found that the data was there, the call to the column's `Value()` method was happening, but the `Scan` call just wasn't setting things properly for any field that appeared after the null number.