### PR TITLE
Discard bad connections before Begin and Prepare, and improve cleanup in Close.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -39,9 +39,7 @@ func (d *Driver) Open(dsn string) (driver.Conn, error) {
 
 func (c *Conn) Close() (err error) {
 	if c.tx != nil {
-		if err := c.tx.Rollback(); err != nil {
-			return err
-		}
+		c.tx.Rollback()
 	}
 	h := c.h
 	defer func() {

--- a/foxpro_test.go
+++ b/foxpro_test.go
@@ -27,6 +27,9 @@ func TestFoxPro(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	if err := db.Ping(); err != nil {
+		t.Skipf("skipping test: %v", err)
+	}
 
 	type row struct {
 		char       string

--- a/odbcstmt.go
+++ b/odbcstmt.go
@@ -31,7 +31,7 @@ func (c *Conn) PrepareODBCStmt(query string) (*ODBCStmt, error) {
 	var out api.SQLHANDLE
 	ret := api.SQLAllocHandle(api.SQL_HANDLE_STMT, api.SQLHANDLE(c.h), &out)
 	if IsError(ret) {
-		return nil, NewError("SQLAllocHandle", c.h)
+		return nil, c.newError("SQLAllocHandle", c.h)
 	}
 	h := api.SQLHSTMT(out)
 	drv.Stats.updateHandleCount(api.SQL_HANDLE_STMT, 1)
@@ -40,7 +40,7 @@ func (c *Conn) PrepareODBCStmt(query string) (*ODBCStmt, error) {
 	ret = api.SQLPrepare(h, (*api.SQLWCHAR)(unsafe.Pointer(&b[0])), api.SQL_NTS)
 	if IsError(ret) {
 		defer releaseHandle(h)
-		return nil, NewError("SQLPrepare", h)
+		return nil, c.newError("SQLPrepare", h)
 	}
 	ps, err := ExtractParameters(h)
 	if err != nil {

--- a/stmt.go
+++ b/stmt.go
@@ -20,6 +20,9 @@ type Stmt struct {
 }
 
 func (c *Conn) Prepare(query string) (driver.Stmt, error) {
+	if c.bad {
+		return nil, driver.ErrBadConn
+	}
 	os, err := c.PrepareODBCStmt(query)
 	if err != nil {
 		return nil, err

--- a/tx.go
+++ b/tx.go
@@ -51,12 +51,13 @@ func (c *Conn) endTx(commit bool) error {
 	}
 	ret := api.SQLEndTran(api.SQL_HANDLE_DBC, api.SQLHANDLE(c.h), howToEnd)
 	if IsError(ret) {
-		err := c.newError("SQLEndTran", c.h)
-		return err
+		c.bad = true
+		return c.newError("SQLEndTran", c.h)
 	}
 	c.tx = nil
 	err := c.setAutoCommitAttr(api.SQL_AUTOCOMMIT_ON)
 	if err != nil {
+		c.bad = true
 		return err
 	}
 	return nil


### PR DESCRIPTION
Note that I also added connection tracking in the test code. That invaded the other tests, for which I apologize. Please suggest a better approach if you have one.

Fixes #58.