### PR TITLE
Mark a connection bad if a transaction fails to start.

### DIFF
--- a/mssql_test.go
+++ b/mssql_test.go
@@ -1681,9 +1681,10 @@ func TestMSSQLMarkBeginBadConn(t *testing.T) {
 			}
 		}()
 
-		// database/sql might return the broken driver.Conn to the pool in
-		// that case the next operation must return driver.ErrBadConn so that
-		// the connection is not returned to the pool again.
+		// database/sql might return the broken driver.Conn to the pool. The
+		// next operation on the driver connection must return
+		// driver.ErrBadConn to prevent the bad connection from getting used
+		// again.
 		if should, is := driver.ErrBadConn, nextFn(dc); should != is {
 			t.Errorf("%s: should=\"%v\", is=\"%v\"", label, should, is)
 		}

--- a/tx.go
+++ b/tx.go
@@ -38,6 +38,7 @@ func (c *Conn) Begin() (driver.Tx, error) {
 	c.tx = &Tx{c: c}
 	err := c.setAutoCommitAttr(api.SQL_AUTOCOMMIT_OFF)
 	if err != nil {
+		c.bad = true
 		return nil, err
 	}
 	return c.tx, nil

--- a/tx.go
+++ b/tx.go
@@ -15,9 +15,13 @@ type Tx struct {
 	c *Conn
 }
 
+var testBeginErr error // used during tests
+
 func (c *Conn) setAutoCommitAttr(a uintptr) error {
-	ret := api.SQLSetConnectUIntPtrAttr(c.h, api.SQL_ATTR_AUTOCOMMIT,
-		a, api.SQL_IS_UINTEGER)
+	if testBeginErr != nil {
+		return testBeginErr
+	}
+	ret := api.SQLSetConnectUIntPtrAttr(c.h, api.SQL_ATTR_AUTOCOMMIT, a, api.SQL_IS_UINTEGER)
 	if IsError(ret) {
 		return c.newError("SQLSetConnectUIntPtrAttr", c.h)
 	}


### PR DESCRIPTION
I have recently been testing how this driver behaves during automatic fail-over when using [SQL Server Availability Groups](https://msdn.microsoft.com/en-us/library/ff877884(v=sql.120).aspx).

When testing from a Linux client using unixODBC 2.3.1 and FreeTDS 0.91 I was able to consistently reproduce an incorrect behavior by causing an unplanned database fail-over while a test client was attempting to update data in a transaction.

This driver correctly returned an `*odbc.Error` from `Conn.Begin` but does not set `Conn.bad = true`. The problem is that `database/sql` (Go 1.4.2) returns the connection to the pool and subsequent calls to `Conn.Begin` return `errors.New("already in a transaction")` and `database/sql` again returns the connection to the pool.

Applying this PR fixes the problem, but I cannot figure out how to reproduce the error in an automated test. I tried to test the scenario with the code in https://github.com/ChrisHines/odbc/commit/e833690e0e75d087122977811c2c0bbbdc499149 but it doesn't reproduce the problem. I think the behavior is different because the availability group listener keeps the network connection open during the fail-over and the ODBC client sees different errors in that case than the technique used by the test to break a proxied TCP connection.

@alexbrainman can you think of a way to test this? How can we make this line return an error?
```go
	err := c.setAutoCommitAttr(api.SQL_AUTOCOMMIT_OFF)
```