### PR TITLE
Minor cleanup

### DIFF
--- a/column.go
+++ b/column.go
@@ -101,7 +101,6 @@ func NewColumn(h api.SQLHSTMT, idx int) (Column, error) {
 	default:
 		return nil, fmt.Errorf("unsupported column type %d", sqltype)
 	}
-	panic("unreachable")
 }
 
 // BaseColumn implements common column functionality.

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -368,7 +368,7 @@ func TestMSSQLCreateInsertDelete(t *testing.T) {
 			continue
 		}
 		if is.weight != want.weight {
-			t.Errorf("I did not know, that %s weights %dkg (%dkg expected)", name, is.weight, want.weight)
+			t.Errorf("I did not know, that %s weighs %fkg (%fkg expected)", name, is.weight, want.weight)
 			continue
 		}
 		if !is.dob.Equal(want.dob) {

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -90,7 +90,7 @@ func (params connParams) getConnAddress() (string, error) {
 func (params connParams) updateConnAddress(address string) error {
 	a := strings.SplitN(address, ":", -1)
 	if len(a) != 2 {
-		fmt.Errorf("listen address must have 2 fields, but %d found", len(a))
+		return fmt.Errorf("listen address must have 2 fields, but %d found", len(a))
 	}
 	params["server"] = a[0]
 	params["port"] = a[1]

--- a/odbcstmt.go
+++ b/odbcstmt.go
@@ -102,7 +102,9 @@ func (s *ODBCStmt) Exec(args []driver.Value) error {
 		// 2) set their (vars) values here;
 		// but rebinding parameters for every new parameter value
 		// should be efficient enough for our purpose.
-		s.Parameters[i].BindValue(s.h, i, a)
+		if err := s.Parameters[i].BindValue(s.h, i, a); err != nil {
+			return err
+		}
 	}
 	if testingIssue5 {
 		time.Sleep(10 * time.Microsecond)

--- a/result.go
+++ b/result.go
@@ -13,7 +13,7 @@ type Result struct {
 }
 
 func (r *Result) LastInsertId() (int64, error) {
-	// TODO(brainman): implement (*Resilt).LastInsertId
+	// TODO(brainman): implement (*Result).LastInsertId
 	return 0, errors.New("not implemented")
 }
 


### PR DESCRIPTION
- mssql_test.go: return error in updateConnAddress
- mssql_test.go: use %f for weight in TestMSSQLCreateInsertDelete
- column.go: remove unreachable code
- odbcstmt.go: return error from BindValue in Exec
- result.go: fix typo

/cc @ChrisHines 