### PR TITLE
Support for parameters with long data types

### DIFF
--- a/mssql_test.go
+++ b/mssql_test.go
@@ -1253,6 +1253,7 @@ var paramTypeTests = []struct {
 	{"datetime overflow", "datetime", time.Date(2013, 9, 9, 14, 07, 15, 123e6, time.Local)},
 	// binary blobs
 	{"small blob", "varbinary", make([]byte, 1)},
+	{"very large blob", "varbinary(max)", make([]byte, 100000)},
 	{"7999 large image", "image", make([]byte, 7999)},
 	{"8000 large image", "image", make([]byte, 8000)},
 	{"8001 large image", "image", make([]byte, 8001)},

--- a/param.go
+++ b/param.go
@@ -174,6 +174,18 @@ func ExtractParameters(h api.SQLHSTMT) ([]Parameter, error) {
 			continue
 		}
 		p.isDescribed = true
+		// SQL Server MAX types (varchar(max), nvarchar(max),
+		// varbinary(max) are identified by size = 0
+		if p.Size == 0 {
+			switch p.SQLType {
+			case api.SQL_VARBINARY:
+				p.SQLType = api.SQL_LONGVARBINARY
+			case api.SQL_VARCHAR:
+				p.SQLType = api.SQL_LONGVARCHAR
+			case api.SQL_WVARCHAR:
+				p.SQLType = api.SQL_WLONGVARCHAR
+			}
+		}
 	}
 	return ps, nil
 }


### PR DESCRIPTION
Unlike freeTDS, the MS ODBC driver (on both Windows and Linux) provides proper support for long data types - varchar/nvarchar/varbinary(max) - where the value is bigger than 8kb.

This change amends the ExtractParameters method to detect these parameters based on the size property.