### PR TITLE
use SQL_WVARCHAR when parameter type is SQL_VARCHAR

### DIFF
--- a/param.go
+++ b/param.go
@@ -69,6 +69,9 @@ func (p *Parameter) BindValue(h api.SQLHSTMT, idx int, v driver.Value) error {
 			sqltype = api.SQL_WLONGVARCHAR
 		case p.isDescribed:
 			sqltype = p.SQLType
+			if p.SQLType == api.SQL_VARCHAR {
+				sqltype = api.SQL_WVARCHAR
+			}
 		case size <= 1:
 			sqltype = api.SQL_WVARCHAR
 		default:


### PR DESCRIPTION
Since the underlying data is already converted to UTF16, passing the data as SQL_VARCHAR will cause `select * from table where column = ?` to not return any result when `column` is of type `varchar`.