### PR TITLE
fix ld warning on macOS

### DIFF
--- a/api/api_unix.go
+++ b/api/api_unix.go
@@ -7,8 +7,7 @@
 
 package api
 
-// #cgo darwin LDFLAGS: -lodbc -L/usr/local/lib
-// #cgo darwin CFLAGS: -I/usr/local/include
+// #cgo darwin LDFLAGS: -lodbc
 // #cgo linux LDFLAGS: -lodbc
 // #include <sql.h>
 // #include <sqlext.h>

--- a/api/api_unix.go
+++ b/api/api_unix.go
@@ -7,8 +7,8 @@
 
 package api
 
-// #cgo darwin LDFLAGS: -lodbc -L/opt/local/lib
-// #cgo darwin CFLAGS: -I/opt/local/include
+// #cgo darwin LDFLAGS: -lodbc -L/usr/local/lib
+// #cgo darwin CFLAGS: -I/usr/local/include
 // #cgo linux LDFLAGS: -lodbc
 // #include <sql.h>
 // #include <sqlext.h>

--- a/api/mksyscall_unix.pl
+++ b/api/mksyscall_unix.pl
@@ -121,8 +121,7 @@ package $package
 
 import "unsafe"
 
-// #cgo darwin LDFLAGS: -lodbc -L/usr/local/lib
-// #cgo darwin CFLAGS: -I/usr/local/include
+// #cgo darwin LDFLAGS: -lodbc
 // #cgo linux LDFLAGS: -lodbc
 // #include <sql.h>
 // #include <sqlext.h>

--- a/api/mksyscall_unix.pl
+++ b/api/mksyscall_unix.pl
@@ -121,8 +121,8 @@ package $package
 
 import "unsafe"
 
-// #cgo darwin LDFLAGS: -lodbc -L/opt/local/lib
-// #cgo darwin CFLAGS: -I/opt/local/include
+// #cgo darwin LDFLAGS: -lodbc -L/usr/local/lib
+// #cgo darwin CFLAGS: -I/usr/local/include
 // #cgo linux LDFLAGS: -lodbc
 // #include <sql.h>
 // #include <sqlext.h>

--- a/api/zapi_unix.go
+++ b/api/zapi_unix.go
@@ -12,8 +12,7 @@ package api
 
 import "unsafe"
 
-// #cgo darwin LDFLAGS: -lodbc -L/usr/local/lib
-// #cgo darwin CFLAGS: -I/usr/local/include
+// #cgo darwin LDFLAGS: -lodbc
 // #cgo linux LDFLAGS: -lodbc
 // #include <sql.h>
 // #include <sqlext.h>

--- a/api/zapi_unix.go
+++ b/api/zapi_unix.go
@@ -12,8 +12,8 @@ package api
 
 import "unsafe"
 
-// #cgo darwin LDFLAGS: -lodbc -L/opt/local/lib
-// #cgo darwin CFLAGS: -I/opt/local/include
+// #cgo darwin LDFLAGS: -lodbc -L/usr/local/lib
+// #cgo darwin CFLAGS: -I/usr/local/include
 // #cgo linux LDFLAGS: -lodbc
 // #include <sql.h>
 // #include <sqlext.h>


### PR DESCRIPTION
on new macOS, no such /opt/ directory, so run go app vis odbc, always happen the ld warning. 
example:
```
ld: warning: directory not found for option '-L/opt/local/lib'
```