### PR TITLE
CGO: FreeBSD support

### DIFF
--- a/api/api_unix.go
+++ b/api/api_unix.go
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+// +build darwin linux freebsd
 // +build cgo
 
 package api
 
 // #cgo darwin LDFLAGS: -lodbc
 // #cgo linux LDFLAGS: -lodbc
+// #cgo freebsd LDFLAGS: -L /usr/local/lib -lodbc
+// #cgo freebsd CFLAGS: -I/usr/local/include
 // #include <sql.h>
 // #include <sqlext.h>
 // #include <stdint.h>

--- a/api/mksyscall_unix.pl
+++ b/api/mksyscall_unix.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Copyright 2012 The Go Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
@@ -114,7 +114,7 @@ print <<EOF;
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+// +build darwin linux freebsd
 // +build cgo
 
 package $package
@@ -123,6 +123,8 @@ import "unsafe"
 
 // #cgo darwin LDFLAGS: -lodbc
 // #cgo linux LDFLAGS: -lodbc
+// #cgo freebsd LDFLAGS: -L /usr/local/lib -lodbc
+// #cgo freebsd CFLAGS: -I/usr/local/include
 // #include <sql.h>
 // #include <sqlext.h>
 import "C"

--- a/api/zapi_unix.go
+++ b/api/zapi_unix.go
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+// +build darwin linux freebsd
 // +build cgo
 
 package api
@@ -14,6 +14,8 @@ import "unsafe"
 
 // #cgo darwin LDFLAGS: -lodbc
 // #cgo linux LDFLAGS: -lodbc
+// #cgo freebsd LDFLAGS: -L /usr/local/lib -lodbc
+// #cgo freebsd CFLAGS: -I/usr/local/include
 // #include <sql.h>
 // #include <sqlext.h>
 import "C"


### PR DESCRIPTION
unixODBC libs/includes are installed under /usr/local via ports/pkg on
a FreeBSD system.