### PR TITLE
Add go-ole to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/alexbrainman/odbc
 
-require golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba
+require (
+	github.com/go-ole/go-ole v1.2.5
+	golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
-golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba h1:nZJIJPGow0Kf9bU9QTc1U6OXbs/7Hu4e+cNv+hxH+Zc=
-golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+github.com/go-ole/go-ole v1.2.5 h1:t4MGB5xEDZvXI+0rMjjsfBsD7yAgp/s9ZDkL1JndXwY=
+github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3 h1:7TYNF4UdlohbFwpNH04CoPMp1cHUZgO1Ebq5r2hIjfo=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Hi,

First of all, thanks for this library, it's been a huge help for us over the last couple of months.

- I created this PR to update the `go.mod` using `go mod tidy`.
- Importing this package leads to having `go-ole` as an indirect dependency in the `go.mod` of the importing project.
- This comes as a result of `odbc` not having `go-ole` in it's `go.mod`.

I'm aware `go-ole` is only used for testing here, but I feel it belongs more to this `go.mod` than the `go.mod`s of the importing packages.

Thanks