### PR TITLE
Specify Homebrew path in cgo FLAGS variables on Macs

### DIFF
--- a/api/api_unix.go
+++ b/api/api_unix.go
@@ -7,7 +7,8 @@
 
 package api
 
-// #cgo darwin LDFLAGS: -lodbc
+// #cgo darwin LDFLAGS: -L /usr/local/opt/unixodbc/lib -lodbc
+// #cgo darwin CFLAGS: -I /usr/local/opt/unixodbc/include
 // #cgo linux LDFLAGS: -lodbc
 // #cgo freebsd LDFLAGS: -L /usr/local/lib -lodbc
 // #cgo freebsd CFLAGS: -I/usr/local/include


### PR DESCRIPTION
Issue #153 describes the problem: On ARM macs, Homebrew stores binaries in a different place from Intel macs (see [docs](https://docs.brew.sh/Installation)). cgo is thus unable to find the unixodbc files. If a user with an ARM Mac has created a symbolic link from the standard Homebrew path to where it's installed, this code makes it work on both ARM Macs and Intel Macs. I'm not sure why, but even if the link is created, it doesn't work without this change. My colleague @hawkaa who has an Intel mac can testify; we used [this reproduction repo](https://github.com/vegarsti/odbc-repro) to verify it on each of our machines. (Just doing `go run main.go` in there.)

I would be very happy if this was approved @alexbrainman!

To create the symbolic link from the ARM Homebrew path to the Intel Homebrew path, do:

```
ln -s ../../../opt/homebrew/opt/unixodbc /usr/local/opt/unixodbc
```

This assumes that `/opt/homebrew/opt/unixodbc` points to the correct version of unixodbc (in my case `unixodbc -> ../Cellar/unixodbc/2.3.9_1`), which Homebrew should have taken care of.