### PR TITLE
fix panic when DB returns an error

### DIFF
--- a/error.go
+++ b/error.go
@@ -47,13 +47,14 @@ func NewError(apiName string, handle interface{}) error {
 	}
 	err := &Error{APIName: apiName}
 	var ne api.SQLINTEGER
+	var msglen api.SQLSMALLINT
 	state := make([]uint16, 6)
 	msg := make([]uint16, api.SQL_MAX_MESSAGE_LENGTH)
 	for i := 1; ; i++ {
 		ret := api.SQLGetDiagRec(ht, h, api.SQLSMALLINT(i),
 			(*api.SQLWCHAR)(unsafe.Pointer(&state[0])), &ne,
 			(*api.SQLWCHAR)(unsafe.Pointer(&msg[0])),
-			api.SQLSMALLINT(len(msg)), nil)
+			api.SQLSMALLINT(len(msg)), &msglen)
 		if ret == api.SQL_NO_DATA {
 			break
 		}


### PR DESCRIPTION
This fixed #184 for me.
api.SQLGetDiagRec is expecting a pointer to a smallint to store the message length but the current implementation passes a nil.
