### PR TITLE
Fix column truncation problem with IBM DB2 for system i

### DIFF
--- a/column.go
+++ b/column.go
@@ -290,8 +290,17 @@ loop:
 			break loop
 		case api.SQL_SUCCESS_WITH_INFO:
 			err := NewError("SQLGetData", h).(*Error)
-			if len(err.Diag) > 0 && err.Diag[0].State != "01004" {
-				return nil, err
+			if len(err.Diag) > 0 {
+				truncated := false
+				for _, diag := range err.Diag {
+					if diag.State == "01004" {
+						truncated = true
+						break
+					}
+				}
+				if !truncated {
+					return nil, err
+				}
 			}
 			i := len(b)
 			switch c.CType {


### PR DESCRIPTION
I have noticed, that ODBC Error code 01004 is handled differently on IBM DB2 for system i.

Instead of the state code 01004 being located in err.Diag[0].State, in IBM's DB2, the code is given in the err.Diag[1].State.
To maximize compatibility, I extended your code to iterate through all of err.Diag's entries to check for this state code. 

This fixes the problem of your library not being able to read past buffer size (1024 bytes).

Thank you for your odbc driver!