### PR TITLE
Fix out-of-bounds panic in BindValue when handling empty byte slices  

### DIFF
--- a/param.go
+++ b/param.go
@@ -138,22 +138,18 @@ func (p *Parameter) BindValue(h api.SQLHSTMT, idx int, v driver.Value, conn *Con
 		}
 		size = 20 + api.SQLULEN(decimal)
 	case []byte:
-
 		ctype = api.SQL_C_BINARY
+		b := make([]byte, len(d))
+		copy(b, d)
+		p.Data = b
 		if len(d) > 0 {
-			b := make([]byte, len(d))
-			copy(b, d)
-			p.Data = b
 			buf = unsafe.Pointer(&b[0])
-			buflen = api.SQLLEN(len(b))
-			plen = p.StoreStrLen_or_IndPtr(buflen)
 		} else {
-			p.Data = nil
 			buf = nil
-			buflen = 0
-			plen = p.StoreStrLen_or_IndPtr(api.SQL_NULL_DATA)
 		}
-		size = api.SQLULEN(len(d))
+		buflen = api.SQLLEN(len(b))
+		plen = p.StoreStrLen_or_IndPtr(buflen)
+		size = api.SQLULEN(len(b))
 		switch {
 		case p.isDescribed:
 			sqltype = p.SQLType

--- a/param.go
+++ b/param.go
@@ -138,14 +138,22 @@ func (p *Parameter) BindValue(h api.SQLHSTMT, idx int, v driver.Value, conn *Con
 		}
 		size = 20 + api.SQLULEN(decimal)
 	case []byte:
+
 		ctype = api.SQL_C_BINARY
-		b := make([]byte, len(d))
-		copy(b, d)
-		p.Data = b
-		buf = unsafe.Pointer(&b[0])
-		buflen = api.SQLLEN(len(b))
-		plen = p.StoreStrLen_or_IndPtr(buflen)
-		size = api.SQLULEN(len(b))
+		if len(d) > 0 {
+			b := make([]byte, len(d))
+			copy(b, d)
+			p.Data = b
+			buf = unsafe.Pointer(&b[0])
+			buflen = api.SQLLEN(len(b))
+			plen = p.StoreStrLen_or_IndPtr(buflen)
+		} else {
+			p.Data = nil
+			buf = nil
+			buflen = 0
+			plen = p.StoreStrLen_or_IndPtr(api.SQL_NULL_DATA)
+		}
+		size = api.SQLULEN(len(d))
 		switch {
 		case p.isDescribed:
 			sqltype = p.SQLType


### PR DESCRIPTION
### **PR Description:**  
**Issue Reference:** #208

#### **Summary:**  
This PR fixes a runtime panic in `BindValue` where an empty byte slice (`[]byte`) could cause an out-of-bounds access when directly referencing `b[0]`.  

#### **Changes:**  
- Added a check to ensure the slice is not empty before accessing its first element.  
- If the slice is empty, `buf` is set to `nil` to prevent unsafe memory access.  

#### **Reproduction Steps:**  
1. Pass an empty `[]byte{}` to `BindValue`.  
2. Previously, this would result in a runtime panic.  
3. With this fix, the function now handles empty slices safely.  

#### **Testing:**  
- Verified with both empty and non-empty byte slices.  
- No functional changes for non-empty cases.  

Let me know if you'd like any refinements before you submit the PR! 🚀