### PR TITLE
 Fix: Byte Parameter Type in Redshift

### DIFF
--- a/param.go
+++ b/param.go
@@ -138,22 +138,18 @@ func (p *Parameter) BindValue(h api.SQLHSTMT, idx int, v driver.Value, conn *Con
 		}
 		size = 20 + api.SQLULEN(decimal)
 	case []byte:
-
 		ctype = api.SQL_C_BINARY
+		b := make([]byte, len(d))
+		copy(b, d)
+		p.Data = b
 		if len(d) > 0 {
-			b := make([]byte, len(d))
-			copy(b, d)
-			p.Data = b
 			buf = unsafe.Pointer(&b[0])
-			buflen = api.SQLLEN(len(b))
-			plen = p.StoreStrLen_or_IndPtr(buflen)
 		} else {
-			p.Data = nil
 			buf = nil
-			buflen = 0
-			plen = p.StoreStrLen_or_IndPtr(api.SQL_NULL_DATA)
 		}
-		size = api.SQLULEN(len(d))
+		buflen = api.SQLLEN(len(b))
+		plen = p.StoreStrLen_or_IndPtr(buflen)
+		size = api.SQLULEN(len(b))
 		switch {
 		case p.isDescribed:
 			sqltype = p.SQLType

--- a/param.go
+++ b/param.go
@@ -144,22 +144,11 @@ func (p *Parameter) BindValue(h api.SQLHSTMT, idx int, v driver.Value, conn *Con
 		p.Data = b
 		if len(d) > 0 {
 			buf = unsafe.Pointer(&b[0])
-		} else {
-			buf = nil
-		}
+		} 
 		buflen = api.SQLLEN(len(b))
 		plen = p.StoreStrLen_or_IndPtr(buflen)
 		size = api.SQLULEN(len(b))
-		switch {
-		case p.isDescribed:
-			sqltype = p.SQLType
-		case size <= 0:
-			sqltype = api.SQL_LONGVARBINARY
-		case size >= 8000:
-			sqltype = api.SQL_LONGVARBINARY
-		default:
-			sqltype = api.SQL_BINARY
-		}
+		sqltype = api.SQL_LONGVARBINARY
 	default:
 		return fmt.Errorf("unsupported type %T", v)
 	}

--- a/param.go
+++ b/param.go
@@ -138,14 +138,22 @@ func (p *Parameter) BindValue(h api.SQLHSTMT, idx int, v driver.Value, conn *Con
 		}
 		size = 20 + api.SQLULEN(decimal)
 	case []byte:
+
 		ctype = api.SQL_C_BINARY
-		b := make([]byte, len(d))
-		copy(b, d)
-		p.Data = b
-		buf = unsafe.Pointer(&b[0])
-		buflen = api.SQLLEN(len(b))
-		plen = p.StoreStrLen_or_IndPtr(buflen)
-		size = api.SQLULEN(len(b))
+		if len(d) > 0 {
+			b := make([]byte, len(d))
+			copy(b, d)
+			p.Data = b
+			buf = unsafe.Pointer(&b[0])
+			buflen = api.SQLLEN(len(b))
+			plen = p.StoreStrLen_or_IndPtr(buflen)
+		} else {
+			p.Data = nil
+			buf = nil
+			buflen = 0
+			plen = p.StoreStrLen_or_IndPtr(api.SQL_NULL_DATA)
+		}
+		size = api.SQLULEN(len(d))
 		switch {
 		case p.isDescribed:
 			sqltype = p.SQLType

--- a/param.go
+++ b/param.go
@@ -144,7 +144,7 @@ func (p *Parameter) BindValue(h api.SQLHSTMT, idx int, v driver.Value, conn *Con
 		p.Data = b
 		if len(d) > 0 {
 			buf = unsafe.Pointer(&b[0])
-		} 
+		}
 		buflen = api.SQLLEN(len(b))
 		plen = p.StoreStrLen_or_IndPtr(buflen)
 		size = api.SQLULEN(len(b))


### PR DESCRIPTION
Description:

Fixes #210

This PR fixes an issue where byte parameters were wrongly mapped to SQL_VARCHAR, causing a type conversion error.

The fix ensures byte data uses SQL_LONGVARBINARY, which database can handle properly.
